### PR TITLE
fix: hide password on stacktrace

### DIFF
--- a/src/jamdb_oracle.app.src
+++ b/src/jamdb_oracle.app.src
@@ -1,6 +1,6 @@
 {application, jamdb_oracle, [
     {description, "Erlang driver for Oracle"},
-    {vsn, "0.4.9.4"},
+    {vsn, "0.4.9.5"},
     {modules, []},
     {registered, []},
     {applications, [kernel,stdlib]},

--- a/src/jamdb_oracle.appup.src
+++ b/src/jamdb_oracle.appup.src
@@ -1,8 +1,6 @@
 %% -*- mode: erlang -*-
-{"0.4.9.4",
-  [{"0.4.9.3",
-    [{load_module,jamdb_oracle,brutal_purge,soft_purge,[]}]},
-   {<<"0\\.4\\.9\\.[1-2]">>,
+{"0.4.9.5",
+  [{<<"0\\.4\\.9\\.[1-4]">>,
     [{restart_application, jamdb_oracle}]},
    {<<"0\\.4\\.[7-9]">>,
     [{restart_application, jamdb_oracle}]},

--- a/src/jamdb_oracle_tns_encoder.erl
+++ b/src/jamdb_oracle_tns_encoder.erl
@@ -86,7 +86,7 @@ encode_record(auth, #oraclient{env=EnvOpts,passwd=Passwd,req=Request,seq=Tseq}) 
     User            = proplists:get_value(user, EnvOpts),
     Role            = proplists:get_value(role, EnvOpts, 0),
     Prelim          = proplists:get_value(prelim, EnvOpts, 0),
-    {Pass, NewPass} = jamdb_oracle_buffer:get(Passwd),
+    {Pass, NewPass} = jamdb_secret:unwrap(Passwd),
     User2 = encode_str(User),
     Pass2 = binary_to_list(encode_str(Pass)),
     NewPass2 = binary_to_list(encode_str(NewPass)),

--- a/src/jamdb_secret.erl
+++ b/src/jamdb_secret.erl
@@ -1,0 +1,37 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2022-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+%% Note: this module CAN'T be hot-patched to avoid invalidating the
+%% closures, so it must not be changed.
+-module(jamdb_secret).
+
+%% API:
+-export([wrap/1, unwrap/1]).
+
+%%================================================================================
+%% API funcions
+%%================================================================================
+
+wrap(Term) ->
+    fun() ->
+        Term
+    end.
+
+unwrap(Term) when is_function(Term, 0) ->
+    %% Handle potentially nested funs
+    unwrap(Term());
+unwrap(Term) ->
+    Term.


### PR DESCRIPTION
Password was being stored in plain text on process dictionary, causing information leaking when stacktrace is printed.