### PR TITLE
fix: handle large text bind formats

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,1 +1,7 @@
 {minimum_otp_vsn, "22.0"}.
+
+{profiles, [
+    {test, [
+        {erl_opts, [{d, 'TEST'}]}
+    ]}
+]}.

--- a/src/jamdb_oracle_conn.erl
+++ b/src/jamdb_oracle_conn.erl
@@ -8,6 +8,10 @@
 -export([get_max_cursors_number/0, set_max_cursors_number/1]).
 -export([reset_cursors/1]).
 
+-ifdef(TEST).
+-export([bind_param_names/1]).
+-endif.
+
 -include("jamdb_oracle.hrl").
 
 -opaque state() :: #oraclient{}.
@@ -121,12 +125,15 @@ sql_query(#oraclient{conn_state=connected} = State, {fetch, Cursor, RowFormat, L
         {ok, State2} -> handle_resp({Cursor, RowFormat, [LastRow]}, State2);
         Err -> Err
     end;
-sql_query(#oraclient{conn_state=connected} = State, {Query, Bind, Batch, Fetch}) ->
+sql_query(#oraclient{conn_state=connected} = State, {Query, Bind0, Batch0, Fetch}) ->
+    {Bind, Batch} = normalize_bind_rows(Query, Bind0, Batch0),
     case send_req(exec, State, {Query, Bind, Batch}) of
         {ok, State2} ->
             #oraclient{server=Ver, defcols=DefCol, params=RowFormat, type=Type} = State2,
-            handle_resp(get_param(defcols, {DefCol, Ver, RowFormat, Type}),
-            State2#oraclient{type=get_param(type, {Type, Fetch})});
+            handle_resp(
+                get_param(defcols, {DefCol, Ver, RowFormat, Type}),
+                State2#oraclient{type=get_param(type, {Type, Fetch})}
+            );
         Err -> Err
     end;
 sql_query(#oraclient{conn_state=connected, timeouts={_Tout, ReadTout}} = State, {Query, Bind}) ->
@@ -255,21 +262,23 @@ send_req(fetch, #oraclient{seq=Task} = State, Cursor) ->
     Data = get_record(fetch, State, Cursor, Task),
     send(State, ?TNS_DATA, Data);
 send_req(exec, State, {Query, Bind, Batch}) when is_map(Bind) ->
-    Data = lists:filtermap(fun(L) -> case string:chr(L, $:) of 0 -> false; I -> {true, lists:nthtail(I, L)} end end,
-        string:tokens(Query," \t;,)")),
-    send_req(exec, State, {Query, get_param(Data, Bind, []), [get_param(Data, B, []) || B <- Batch]});
+    {Bind2, Batch2} = normalize_bind_rows(Query, Bind, Batch),
+    send_req(exec, State, {Query, Bind2, Batch2});
 send_req(exec, #oraclient{charset=Charset,fetch=Fetch,cursors=Cursors,seq=Task} = State, {Query, Bind, Batch}) ->
     KeyWord = lists:nth(1, string:tokens(string:to_upper(Query)," \t\r\n")),
     {Select, Change} = ?ENCODER:encode_helper(type, KeyWord),
     {Type, Fetch2} = get_param(type, {Select, Change, [B || {out, B} <- Bind], Fetch}),
-    Sum = erlang:crc32(?ENCODER:encode_str(Query)),
+    BindFormat = get_bind_format(Charset, [Bind | Batch]),
+    Sum = erlang:crc32(term_to_binary({?ENCODER:encode_str(Query), bind_format_signature(BindFormat)})),
     DefCol = get_param(defcols, {Sum, Cursors}),
     {LCursor, Cursor} = get_param(defcols, DefCol),
     Pig = if Cursor =/= 0 -> get_record(pig, [], {?TTI_CANA, [Cursor]}, Task); true -> <<>> end,
     Pig2 = if Cursor =/= 0 -> get_record(pig, [], {?TTI_OCCA, [Cursor]}, Task); true -> <<>> end,
+    BindData = [get_param(data, B) || B <- Bind],
+    BatchData = [[get_param(data, B) || B <- Row] || Row <- Batch],
     Data = get_record(exec, State#oraclient{type=Type,fetch=Fetch2}, {LCursor, if LCursor =:= 0 -> Query; true -> [] end,
-        [get_param(data, B) || B <- Bind], Batch, []}, Task),
-    send(State#oraclient{type=Type,defcols=DefCol,params=[get_param(format, B, #format{charset=Charset}) || B <- Bind]},
+        BindData, BatchData, [], BindFormat}, Task),
+    send(State#oraclient{type=Type,defcols=DefCol,params=BindFormat},
         ?TNS_DATA, <<Pig/binary, Pig2/binary, Data/binary>>).
 
 handle_resp(Acc, #oraclient{socket=Socket, sdu=Length, timeouts=Touts} = State) ->
@@ -399,6 +408,125 @@ get_param(type, {Type, []}) -> Type;
 get_param(data, {out, Data}) -> ?ENCODER:encode_helper(param, Data);
 get_param(data, {in, Data}) -> Data;
 get_param(data, Data) -> Data.
+
+normalize_bind_rows(Query, Bind, Batch) when is_map(Bind) ->
+    ParamNames = bind_param_names(Query),
+    {get_param(ParamNames, Bind, []), [get_param(ParamNames, B, []) || B <- Batch]};
+normalize_bind_rows(_Query, Bind, Batch) ->
+    {Bind, Batch}.
+
+bind_param_names(Query) ->
+    bind_param_names(Query, normal, []).
+
+%% Extract map-bind names in SQL order while ignoring quoted/commented text.
+bind_param_names([], _State, Acc) ->
+    lists:reverse(Acc);
+bind_param_names([$q, $', Delimiter|Rest], normal, Acc) ->
+    bind_param_names(Rest, {q_quote, q_quote_end(Delimiter)}, Acc);
+bind_param_names([$Q, $', Delimiter|Rest], normal, Acc) ->
+    bind_param_names(Rest, {q_quote, q_quote_end(Delimiter)}, Acc);
+bind_param_names([$'|Rest], normal, Acc) ->
+    bind_param_names(Rest, single_quote, Acc);
+bind_param_names([$"|Rest], normal, Acc) ->
+    bind_param_names(Rest, double_quote, Acc);
+bind_param_names([$-, $-|Rest], normal, Acc) ->
+    bind_param_names(Rest, line_comment, Acc);
+bind_param_names([$/, $*|Rest], normal, Acc) ->
+    bind_param_names(Rest, block_comment, Acc);
+bind_param_names([$:, $=|Rest], normal, Acc) ->
+    bind_param_names(Rest, normal, Acc);
+bind_param_names([$:|Rest], normal, Acc) ->
+    {Name, Rest2} = read_bind_name(Rest, []),
+    case Name of
+        [] -> bind_param_names(Rest2, normal, Acc);
+        _ -> bind_param_names(Rest2, normal, [Name|Acc])
+    end;
+bind_param_names([_|Rest], normal, Acc) ->
+    bind_param_names(Rest, normal, Acc);
+bind_param_names([$',$'|Rest], single_quote, Acc) ->
+    bind_param_names(Rest, single_quote, Acc);
+bind_param_names([$'|Rest], single_quote, Acc) ->
+    bind_param_names(Rest, normal, Acc);
+bind_param_names([_|Rest], single_quote, Acc) ->
+    bind_param_names(Rest, single_quote, Acc);
+bind_param_names([$",$"|Rest], double_quote, Acc) ->
+    bind_param_names(Rest, double_quote, Acc);
+bind_param_names([$"|Rest], double_quote, Acc) ->
+    bind_param_names(Rest, normal, Acc);
+bind_param_names([_|Rest], double_quote, Acc) ->
+    bind_param_names(Rest, double_quote, Acc);
+bind_param_names([$\n|Rest], line_comment, Acc) ->
+    bind_param_names(Rest, normal, Acc);
+bind_param_names([$\r|Rest], line_comment, Acc) ->
+    bind_param_names(Rest, normal, Acc);
+bind_param_names([_|Rest], line_comment, Acc) ->
+    bind_param_names(Rest, line_comment, Acc);
+bind_param_names([$*, $/|Rest], block_comment, Acc) ->
+    bind_param_names(Rest, normal, Acc);
+bind_param_names([_|Rest], block_comment, Acc) ->
+    bind_param_names(Rest, block_comment, Acc);
+bind_param_names([End, $'|Rest], {q_quote, End}, Acc) ->
+    bind_param_names(Rest, normal, Acc);
+bind_param_names([_|Rest], {q_quote, End}, Acc) ->
+    bind_param_names(Rest, {q_quote, End}, Acc).
+
+read_bind_name([Char|Rest], Acc) when
+    $a =< Char, Char =< $z;
+    $A =< Char, Char =< $Z;
+    $0 =< Char, Char =< $9;
+    Char =:= $_;
+    Char =:= $$;
+    Char =:= $#
+->
+    read_bind_name(Rest, [Char|Acc]);
+read_bind_name(Rest, Acc) ->
+    {lists:reverse(Acc), Rest}.
+
+q_quote_end($[) -> $];
+q_quote_end(${) -> $};
+q_quote_end($() -> $);
+q_quote_end($<) -> $>;
+q_quote_end(Char) -> Char.
+
+get_bind_format(Charset, Rows) ->
+    Format = #format{charset=Charset},
+    merge_bind_format([[get_param(format, B, Format) || B <- Row] || Row <- Rows]).
+
+merge_bind_format([]) ->
+    [];
+merge_bind_format([BindFormat | Rest]) ->
+    lists:foldl(fun merge_bind_format/2, BindFormat, Rest).
+
+merge_bind_format(BindFormat, Acc) ->
+    [merge_format(L, R) || {L, R} <- lists:zip(Acc, BindFormat)].
+
+merge_format(#format{data_type=DataType} = Format, #format{data_type=DataType} = Other) ->
+    Format#format{
+        data_length = max_format_value(Format#format.data_length, Other#format.data_length),
+        data_scale = max_format_value(Format#format.data_scale, Other#format.data_scale)
+    };
+merge_format(#format{data_type=?TNS_TYPE_VARCHAR, data_length=4000}, Other) ->
+    Other;
+merge_format(Format, #format{data_type=?TNS_TYPE_VARCHAR, data_length=4000}) ->
+    Format;
+merge_format(Format, Other) ->
+    case max_format_value(Format#format.data_length, 0) >= max_format_value(Other#format.data_length, 0) of
+        true -> Format;
+        false -> Other
+    end.
+
+max_format_value(undefined, Value) ->
+    Value;
+max_format_value(Value, undefined) ->
+    Value;
+max_format_value(Left, Right) ->
+    max(Left, Right).
+
+bind_format_signature(BindFormat) ->
+    [
+        {Type, Length, Scale, Charset}
+     || #format{data_type=Type, data_length=Length, data_scale=Scale, charset=Charset} <- BindFormat
+    ].
 
 get_record(Type, [], Request, Task) ->
     ?ENCODER:encode_record(Type, #oraclient{req=Request, seq=get_param(Task)});

--- a/src/jamdb_oracle_tns_encoder.erl
+++ b/src/jamdb_oracle_tns_encoder.erl
@@ -186,7 +186,9 @@ encode_record(fetch, #oraclient{fetch=Fetch,req=Cursor,seq=Tseq}) ->
     (encode_sb4(Cursor))/binary,    %cursor
     (encode_sb4(Fetch))/binary      %rows to fetch
     >>;
-encode_record(exec, #oraclient{type=Type,auto=Auto,charset=Charset,fetch=Fetch,server=Ver,req={Cursor,Query,Bind,Batch,Def},seq=Tseq}) ->
+encode_record(exec, #oraclient{req={Cursor, Query, Bind, Batch, Def}} = State) ->
+    encode_record(exec, State#oraclient{req={Cursor, Query, Bind, Batch, Def, []}});
+encode_record(exec, #oraclient{type=Type,auto=Auto,charset=Charset,fetch=Fetch,server=Ver,req={Cursor,Query,Bind,Batch,Def,BindFormat},seq=Tseq}) ->
     QueryData = encode_str(Query),
     QueryLen = if Cursor =/= 0 -> 0; true -> byte_size(QueryData) end,
     BindLen = length(Bind),
@@ -235,7 +237,7 @@ encode_record(exec, #oraclient{type=Type,auto=Auto,charset=Charset,fetch=Fetch,s
     (case {BindLen, DefLen, QueryLen} of
         {0, 0, QueryLen} -> <<>>;
         {BindLen, 0, 0} -> encode_token(rxd, [Bind|Batch], <<>>);
-        {BindLen, 0, QueryLen} -> encode_token(rxd, [Bind|Batch], encode_token(oac, Bind, #format{charset=Charset}, <<>>));
+        {BindLen, 0, QueryLen} -> encode_token(rxd, [Bind|Batch], encode_token(oac, bind_format(Bind, BindFormat), #format{charset=Charset}, <<>>));
         {0, DefLen, 0} -> encode_token(oac, Def, #format{charset=Charset}, <<>>)
     end)/binary
     >>;
@@ -254,8 +256,14 @@ encode_record(close, #oraclient{seq=Tseq}) ->
     >>.
 
 setopts(all8, {Opts, Fetch, Type}) -> [Opts,Fetch,0,0,0,0,0,Type,0,0,0,0,0];
-setopts(size, Data) when length(Data) > 4000 -> 33554432;  %clob
-setopts(size, _Data) -> 4000.
+setopts(size, Data) ->
+    case byte_size(encode_str(Data)) > 4000 of
+        true -> 33554432;  %clob
+        false -> 4000
+    end.
+
+bind_format(Bind, []) -> Bind;
+bind_format(_Bind, BindFormat) -> BindFormat.
 
 setopts(fetch, DefInd, _BatchLen, Fetch) ->
     {32832 bor (DefInd * 16), 0, 2147483647, setopts(all8, {0, Fetch, 1})};
@@ -304,6 +312,9 @@ encode_token(oac, [Data|Rest], Format, Acc) when is_record(Data, format), is_bin
     encode_token(oac, Rest, Format, <<Acc/binary, (encode_token(oac, Data, Format,[]))/binary>>);
 encode_token(oac, [Data|Rest], Format, Acc) when is_binary(Acc) ->
     encode_token(oac, Rest, Format, <<Acc/binary, (encode_token(oac, Data, Format))/binary>>);
+encode_token(oac, #format{data_type=DataType,data_length=Length,charset=Charset}, _, Acc)
+when is_list(Acc), ?IS_CHAR_TYPE(DataType), Length > 4000 ->
+    encode_token(oac, ?TNS_TYPE_VARCHAR, Length, 16, Charset, 0);
 encode_token(oac, #format{data_type=DataType,charset=Charset}, _, Acc) when is_list(Acc), ?IS_CHAR_TYPE(DataType) ->
     encode_token(oac, ?TNS_TYPE_VARCHAR, 4000, 16, Charset, 0);
 encode_token(oac, #format{data_type=DataType,charset=Charset}, _, Acc) when is_list(Acc), ?IS_LOB_TYPE(DataType) ->

--- a/test/jamdb_oracle_SUITE.erl
+++ b/test/jamdb_oracle_SUITE.erl
@@ -51,7 +51,11 @@ groups() ->
         {lob_datatypes, [sequence], [
             t_clob,
             t_blob,
-            t_nclob            
+            t_nclob,
+            t_nclob_bind_size_changes,
+            t_nclob_bind_mb,
+            t_nclob_bind_named_batch,
+            t_nclob_bind_tuple_batch
         ]},
         {rowid_datatypes, [sequence], [
             t_rowid
@@ -325,6 +329,80 @@ t_nclob(Config) ->
     ],
     run_testcases(ConnRef, Table, Key, TestCases).
 
+%% Verifies that the same SQL can first bind NCLOB data as regular small text
+%% and later bind it as large text.  Also verifies batch execution where only a
+%% later row requires the large-text bind format.
+t_nclob_bind_size_changes(Config) ->
+    ConnRef = ?config(conn_ref, Config),
+    Query = "insert into t_nclob_bind_size_changes(C_ID, C_NCLOB) values(:1, :2)",
+    SmallValue = "small",
+    LargeValue = lists:duplicate(5000, $a),
+    %% The same SQL text must work first with a small text bind and then with a
+    %% large text bind, so cursor cache entries include bind format metadata.
+    {ok, [{affected_rows,1}]} = jamdb_oracle:sql_query(ConnRef, {Query, ["small", SmallValue]}),
+    {ok, [{affected_rows,1}]} = jamdb_oracle:sql_query(ConnRef, {Query, ["large", LargeValue]}),
+    assert_count(ConnRef, t_nclob_bind_size_changes, 2),
+    {ok, [{affected_rows,2}]} = jamdb_oracle:sql_query(ConnRef, "delete from t_nclob_bind_size_changes"),
+    ok = jamdb_oracle:reset_cursors(ConnRef),
+    %% Batch metadata must be computed from all rows, not only the first row.
+    {ok, [{affected_rows,2}]} =
+        jamdb_oracle:sql_query(ConnRef, {batch, Query, [["batch-small", SmallValue], ["batch-large", LargeValue]]}),
+    assert_count(ConnRef, t_nclob_bind_size_changes, 2).
+
+%% Verifies that the large-text threshold is based on the encoded byte size,
+%% not the Erlang character count.  This matters for multibyte text that is
+%% shorter than 4000 characters but longer than 4000 encoded bytes.
+t_nclob_bind_mb(Config) ->
+    ConnRef = ?config(conn_ref, Config),
+    Query = "insert into t_nclob_bind_mb(C_ID, C_NCLOB) values(:1, :2)",
+    LargeValue = lists:duplicate(2000, 16#4E00),
+    %% Large text detection must use encoded byte size, not Erlang list length.
+    {ok, [{affected_rows,1}]} =
+        jamdb_oracle:sql_query(ConnRef, {Query, ["large-multibyte", LargeValue]}),
+    assert_count(ConnRef, t_nclob_bind_mb, 1).
+
+%% Verifies named batch binds.  Map values have no SQL order, so the driver
+%% must read placeholder order from the statement before it can merge bind
+%% formats across rows.
+t_nclob_bind_named_batch(Config) ->
+    ConnRef = ?config(conn_ref, Config),
+    Query =
+        "insert into t_nclob_bind_named_batch(C_ID, C_TAG, C_NCLOB) values("
+        ":id, :tag, :payload)",
+    LargeValue = lists:duplicate(5000, $a),
+    %% Named batch binds are map values, so the driver must derive bind order
+    %% from the SQL text before merging per-row bind formats.
+    {ok, [{affected_rows,2}]} =
+        jamdb_oracle:sql_query(
+            ConnRef,
+            {batch, Query, [
+                #{id => "named-batch-1", payload => "small", tag => "small"},
+                #{id => "named-batch-2", payload => LargeValue, tag => "large"}
+            ]}
+        ),
+    assert_count(ConnRef, t_nclob_bind_named_batch, 2).
+
+%% Verifies tuple batch binds.  This path already has positional bind order,
+%% but it still needs merged bind formats when a later batch row contains
+%% large NCLOB data.
+t_nclob_bind_tuple_batch(Config) ->
+    ConnRef = ?config(conn_ref, Config),
+    Query =
+        "insert into t_nclob_bind_tuple_batch(C_ID, C_TAG, C_NCLOB) values("
+        ":1, :2, :3)",
+    LargeValue = lists:duplicate(5000, $a),
+    %% The raw tuple form bypasses map ordering, but still relies on merged
+    %% bind formats when later batch rows contain large text.
+    {ok, [{affected_rows,2}]} =
+        jamdb_oracle:sql_query(
+            ConnRef,
+            {Query,
+                ["tuple-batch-1", "small", "small"],
+                [["tuple-batch-2", "large", LargeValue]],
+                []}
+        ),
+    assert_count(ConnRef, t_nclob_bind_tuple_batch, 2).
+
 t_rowid(Config) ->
     ConnRef = ?config(conn_ref, Config),
     Table = t_rowid,
@@ -393,6 +471,14 @@ table_desc(t_blob) ->
     "C_BLOB BLOB";
 table_desc(t_nclob) ->
     "C_NCLOB NCLOB";
+table_desc(t_nclob_bind_size_changes) ->
+    "C_ID VARCHAR2(32), C_NCLOB NCLOB";
+table_desc(t_nclob_bind_mb) ->
+    "C_ID VARCHAR2(32), C_NCLOB NCLOB";
+table_desc(t_nclob_bind_named_batch) ->
+    "C_ID VARCHAR2(32), C_NCLOB NCLOB, C_TAG VARCHAR2(32)";
+table_desc(t_nclob_bind_tuple_batch) ->
+    "C_ID VARCHAR2(32), C_NCLOB NCLOB, C_TAG VARCHAR2(32)";
 table_desc(t_rowid) ->
     "C_ROWID ROWID".
 
@@ -457,6 +543,17 @@ select(ConnRef, Table) ->
 delete(ConnRef, Table) ->
     Query = lists:concat(["delete from ", Table]),
     jamdb_oracle:sql_query(ConnRef, Query).
+
+assert_count(ConnRef, Table, Expected) ->
+    Query = lists:concat(["select count(*) C_COUNT from ", Table]),
+    {ok, [{result_set, [<<"C_COUNT">>], [], [[{Count}]]}]} = jamdb_oracle:sql_query(ConnRef, Query),
+    Expected = normalize_number(Count),
+    ok.
+
+normalize_number(Number) when is_integer(Number) ->
+    Number;
+normalize_number(Number) when is_float(Number) ->
+    trunc(Number).
 
 %% Temporary wrapper
 format_query(Query, Args) ->

--- a/test/jamdb_oracle_conn_tests.erl
+++ b/test/jamdb_oracle_conn_tests.erl
@@ -1,0 +1,109 @@
+-module(jamdb_oracle_conn_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% Verifies placeholder extraction for SQL shapes commonly generated from EMQX
+%% Oracle actions.  These tests document the expected bind order for DML
+%% statements before map bind values are converted to positional binds.
+bind_param_names_action_sqls_test_() ->
+    [
+        {"default insert", fun() ->
+            assert_bind_param_names(
+                ["1", "2", "3", "4"],
+                "insert into t_mqtt_msgs(msgid, topic, qos, payload) "
+                "values (:1, :2, :3, :4)"
+            )
+        end},
+        {"bridge insert", fun() ->
+            assert_bind_param_names(
+                ["1", "2", "3", "4"],
+                "INSERT INTO mqtt_test(topic, msgid, payload, retain) "
+                "VALUES (:1, :2, :3, :4)"
+            )
+        end},
+        {"update", fun() ->
+            assert_bind_param_names(
+                ["1", "2", "3", "4"],
+                "UPDATE mqtt_test SET payload = :1, retain = :2 "
+                "WHERE topic = :3 AND msgid = :4"
+            )
+        end},
+        {"delete", fun() ->
+            assert_bind_param_names(
+                ["1", "2"],
+                "DELETE FROM mqtt_test WHERE topic = :1 AND msgid = :2"
+            )
+        end},
+        {"merge", fun() ->
+            assert_bind_param_names(
+                ["1", "2", "3", "4"],
+                "MERGE INTO mqtt_test dst "
+                "USING (SELECT :1 topic, :2 msgid, :3 payload, :4 retain FROM dual) src "
+                "ON (dst.topic = src.topic AND dst.msgid = src.msgid) "
+                "WHEN MATCHED THEN UPDATE SET dst.payload = src.payload, dst.retain = src.retain "
+                "WHEN NOT MATCHED THEN INSERT (topic, msgid, payload, retain) "
+                "VALUES (src.topic, src.msgid, src.payload, src.retain)"
+            )
+        end}
+    ].
+
+%% Verifies scanner boundaries that must not be treated as bind placeholders,
+%% such as quoted strings, quoted identifiers, comments, q-quoted literals, and
+%% PL/SQL assignment syntax.
+bind_param_names_scanner_edges_test_() ->
+    [
+        {"named bind order", fun() ->
+            assert_bind_param_names(
+                ["id", "payload", "id", "tag", "tag"],
+                "select :id, :payload, :id from dual where :tag = :tag"
+            )
+        end},
+        {"quoted and commented text", fun() ->
+            assert_bind_param_names(
+                ["one", "one"],
+                "select :one one from dual \"D:UAL\" \"D\"\":UAL\" -- :line_ignored\n"
+                "where ':string_ignored' = 'It''s :still_ignored' "
+                "and 1=:one /* :block_ignored */"
+            )
+        end},
+        {"line comment ended by carriage return", fun() ->
+            assert_bind_param_names(
+                ["one", "one"],
+                "select :one one from dual -- :line_ignored\r"
+                "where 1=:one"
+            )
+        end},
+        {"q quoted text", fun() ->
+            assert_bind_param_names(
+                ["one", "one"],
+                "select :one one from dual where "
+                "q'[I'm :not_a_bind]' = q'[I'm :not_a_bind]' and "
+                "q'{:brace_ignored}' = q'{:brace_ignored}' and "
+                "q'(:paren_ignored)' = q'(:paren_ignored)' and "
+                "Q'<:angle_ignored>' = Q'<:angle_ignored>' and "
+                "q'!:custom_ignored!' = q'!:custom_ignored!' and "
+                "1=:one"
+            )
+        end},
+        {"plsql assignment", fun() ->
+            assert_bind_param_names(
+                ["value"],
+                "declare x number; begin x := :value; end;"
+            )
+        end},
+        {"oracle bind name chars", fun() ->
+            assert_bind_param_names(
+                ["a_1", "b$2", "c#3"],
+                "select :a_1, :b$2, :c#3 from dual"
+            )
+        end},
+        {"empty bind name after colon", fun() ->
+            assert_bind_param_names(
+                [],
+                "select : from dual"
+            )
+        end}
+    ].
+
+assert_bind_param_names(Expected, Query) ->
+    ?assertEqual(Expected, jamdb_oracle_conn:bind_param_names(Query)).


### PR DESCRIPTION
## Summary

Fixes Oracle action writes where a payload bind grows from small text to more than 4000 bytes.

The driver previously reused cursors by SQL text only and encoded batch bind metadata from the first row. If the same SQL was first prepared with a small payload and later reused with a large payload, or if later batch rows had large payloads, Oracle could reject the bind with `ORA-01461` or close/cancel the connection.

## Fix

- Include bind format metadata in the cursor cache key.
- Merge bind formats across all batch rows before encoding bind metadata.
- Detect large text by encoded byte size, so multi-byte payloads cross the 4000-byte boundary correctly.

The execution path remains native SQL. This PR does not rewrite SQL into PL/SQL or split batches row by row. For Oracle `LONG`/`LOB` bind ordering limits such as `ORA-24816`, callers should keep the large payload/CLOB bind as the trailing bind parameter.
